### PR TITLE
Fixes and new methods

### DIFF
--- a/src/event-kind-handler/EventKindHandlerFactory.ts
+++ b/src/event-kind-handler/EventKindHandlerFactory.ts
@@ -101,7 +101,7 @@ export class EventKindHandlerFactory {
           this.handlers.set(eventKind, new VerifiedKeyAgentsHandler(stores.get(eventKind)!, getContacts, getProfiles))
           break
         case SmartVaultsKind.KeyAgents:
-          this.handlers.set(eventKind, new UnverifiedKeyAgentsHandler(stores.get(eventKind)!, getContacts, getProfiles, getVerifiedKeyAgentsPubKeys))
+          this.handlers.set(eventKind, new UnverifiedKeyAgentsHandler(stores.get(eventKind)!, authenticator, nostrClient, getContacts, getProfiles, getVerifiedKeyAgentsPubKeys))
           break
         case SmartVaultsKind.SignerOffering:
           this.handlers.set(eventKind, new SignerOfferingsHandler(authenticator, nostrClient, stores.get(eventKind)!, eventsStore, getOwnedSignersByOfferingIdentifiers, getSharedSignersByOfferingIdentifiers, getContacts))

--- a/src/event-kind-handler/UnverifiedKeyAgentsHandler.ts
+++ b/src/event-kind-handler/UnverifiedKeyAgentsHandler.ts
@@ -1,17 +1,23 @@
-import { type Event } from 'nostr-tools'
+import { Kind, type Event } from 'nostr-tools'
 import { EventKindHandler } from './EventKindHandler'
 import { KeyAgent, Profile } from '../types'
 import { Contact } from '../models'
-import { type Store } from '../service'
-
+import { NostrClient, type Store } from '../service'
+import { type Authenticator } from '@smontero/nostr-ual'
+import { buildEvent } from '../util'
+import { TagType } from '../enum'
 export class UnverifiedKeyAgentsHandler extends EventKindHandler {
+    private readonly store: Store
+    private readonly authenticator: Authenticator
+    private readonly nostrClient: NostrClient
     private readonly getContacts: () => Promise<Array<Contact>>
     private readonly getProfiles: (pubkeys: string[]) => Promise<Array<Profile>>
     private readonly getVerifiedKeyAgentsPubKeys: () => Promise<string[]>
-    private readonly store: Store
-    constructor(store: Store, getContacts: () => Promise<Array<Contact>>, getProfiles: (pubkeys: string[]) => Promise<Array<Profile>>, getVerifiedKeyAgentsPubKeys: () => Promise<string[]>) {
+    constructor(store: Store, authenticator: Authenticator, nostrClient: NostrClient, getContacts: () => Promise<Array<Contact>>, getProfiles: (pubkeys: string[]) => Promise<Array<Profile>>, getVerifiedKeyAgentsPubKeys: () => Promise<string[]>) {
         super()
         this.store = store
+        this.authenticator = authenticator
+        this.nostrClient = nostrClient
         this.getContacts = getContacts
         this.getProfiles = getProfiles
         this.getVerifiedKeyAgentsPubKeys = getVerifiedKeyAgentsPubKeys
@@ -37,7 +43,8 @@ export class UnverifiedKeyAgentsHandler extends EventKindHandler {
 
         const keyAgents: Array<KeyAgent> = []
 
-        for (const pubkey of unverifiedKeyAgentsPubKeys) {
+        for (const event of unverifiedKeyAgentsEvents) {
+            const pubkey = event.pubkey;
             const isCached = this.store.has(pubkey);
             const isContact = contactsSet.has(pubkey);
             if (isCached) {
@@ -46,11 +53,23 @@ export class UnverifiedKeyAgentsHandler extends EventKindHandler {
             }
             const profile = profilesMap.get(pubkey) || { publicKey: pubkey };
 
-            keyAgents.push({ pubkey, profile, isContact, isVerified: false });
+            keyAgents.push({ pubkey, profile, isContact, isVerified: false, eventId: event.id });
         };
 
         this.store.store(keyAgents);
 
         return this.store.getManyAsArray(unverifiedKeyAgentsPubKeys, 'pubkey');
+    }
+
+    protected async _delete(keyAgentIds: string[]): Promise<void> {
+        const tags = keyAgentIds.map(id => [TagType.Event, id])
+        const deleteEvent = await buildEvent({
+            kind: Kind.EventDeletion,
+            content: '',
+            tags
+        }, this.authenticator)
+        await this.nostrClient.publish(deleteEvent).onFirstOkOrCompleteFailure();
+        const keyAgents = this.store.getManyAsArray(keyAgentIds, 'eventId');
+        if (keyAgents.length) this.store.delete(keyAgents);
     }
 }


### PR DESCRIPTION
Includes the following fixes: 
- key agents: make cache sensible to 'isContact' changes
- creating vaults: remove any potential duplicates in nostrPublickeys array

Includes the following new methods for SmartVaults class:
- getPoliciesByAuthor: fetches the vaults created by a given user #49 
- deleteKeyAgentsSignalingEvent: deletes the signaling event of the logged user (optionally deletes signer offerings) #47 