### PR TITLE
feature/expected-signers

### DIFF
--- a/src/event-kind-handler/EventKindHandlerFactory.ts
+++ b/src/event-kind-handler/EventKindHandlerFactory.ts
@@ -55,6 +55,7 @@ export class EventKindHandlerFactory {
       const deleteSignerOfferings = this.smartVaults.deleteSignerOfferings
       const getPolicyMembers = this.smartVaults.getPolicyMembers
       const saveTransactionMetadata = this.smartVaults.saveTransactionMetadata
+      const getPoliciesById = this.smartVaults.getPoliciesById
       const eventsStore = stores.get(StoreKind.Events)!
       const completedProposalsStore = stores.get(SmartVaultsKind.CompletedProposal)!
       const proposalsStore = stores.get(SmartVaultsKind.Proposal)!
@@ -68,7 +69,7 @@ export class EventKindHandlerFactory {
             getSharedKeysById, getCompletedProposalsByPolicyId, getProposalsByPolicyId, getApprovalsByPolicyId, getSharedSigners, getOwnedSigners, getTransactionMetadataByPolicyId, saveTransactionMetadata))
           break
         case SmartVaultsKind.Proposal:
-          this.handlers.set(eventKind, new ProposalHandler(stores.get(eventKind)!, eventsStore, approvalsStore, nostrClient, bitcoinUtil, authenticator, getSharedKeysById, checkPsbts, getOwnedSigners, getApprovalsByProposalId))
+          this.handlers.set(eventKind, new ProposalHandler(stores.get(eventKind)!, eventsStore, approvalsStore, nostrClient, bitcoinUtil, authenticator, getSharedKeysById, checkPsbts, getOwnedSigners, getApprovalsByProposalId, getPoliciesById))
           break
         case SmartVaultsKind.ApprovedProposal:
           this.handlers.set(eventKind, new ApprovalsHandler(stores.get(eventKind)!, eventsStore, nostrClient, authenticator, getSharedKeysById))

--- a/src/models/interfaces.ts
+++ b/src/models/interfaces.ts
@@ -1,5 +1,5 @@
 import { BaseOwnedSigner, Trx, FinalizeTrxResponse, UndecoratedBasicTrxDetails, UndecoratedTrxDetails, Utxo, PolicyPathSelector, PolicyPathsResult, Address } from "./types"
-import { PsbtObject } from "../types"
+import { PsbtObject, PolicyPath } from "../types"
 
 type BalancePayload = {
   confirmed: number
@@ -26,7 +26,7 @@ export interface Wallet {
   * @param {Map<string,Array<number>>} policy_path
   * @returns {Promise<any>}
   */
-  build_trx(address: string, amount: string, fee_rate: string, policy_path?: Map<string, Array<number>>, utxos?: Array<string>, frozen_utxos?: Array<string>): Promise<Trx>;
+  build_trx(address: string, amount: string, fee_rate: string, policy_path?: PolicyPath, utxos?: Array<string>, frozen_utxos?: Array<string>): Promise<Trx>;
 
   /**
   * @returns {Map<string, any>}

--- a/src/service/NostrClient.test.ts
+++ b/src/service/NostrClient.test.ts
@@ -15,12 +15,12 @@ describe('NostrClient', () => {
   beforeAll(async () => {
     authenticator = new DirectPrivateKeyAuthenticator(generatePrivateKey())
     clientTwoRelays = new NostrClient([
-      'wss://relay.rip',
+      'ws://localhost:7777',
       'wss://relay.snort.social'
     ])
 
     clientOneOkRelay = new NostrClient([
-      'wss://relay.rip',
+      'ws://localhost:7777',
     ])
 
     clientOneFailRelay = new NostrClient([
@@ -48,14 +48,14 @@ describe('NostrClient', () => {
       let result = await pub.completePromise()
       expect(result).toHaveProperty('ok')
       expect(result).toHaveProperty('failed')
-      expect(result.ok).toEqual(['wss://relay.rip'])
+      expect(result.ok).toEqual(['ws://localhost:7777'])
       expect(result.failed).toEqual(['wss://relay.snort.social'])
 
       pub = clientOneOkRelay.publish(event)
       result = await pub.completePromise()
       expect(result).toHaveProperty('ok')
       expect(result).toHaveProperty('failed')
-      expect(result.ok).toEqual(['wss://relay.rip'])
+      expect(result.ok).toEqual(['ws://localhost:7777'])
       expect(result.failed).toEqual([])
 
       pub = clientOneFailRelay.publish(event)

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,7 +49,7 @@ export type SpendProposalPayload = {
   amountDescriptor: string,
   feeRatePriority: string,
   createdAt?: Date,
-  policyPath?: Map<string, Array<number>>
+  policyPath?: PolicyPath
   utxos?: Array<string>
   useFrozenUtxos?: boolean
   keyAgentPayment?: BaseKeyAgentPaymentProposal
@@ -102,10 +102,13 @@ type BaseProposal = {
   psbt: string
 }
 
+export type PolicyPath = { [key: string]: number[] }
+
 type BaseSpendingProposal = {
   to_address: string
   amount: number
   description: string,
+  policy_path?: PolicyPath
 }
 
 export type SpendingProposal = {
@@ -124,7 +127,7 @@ type PublishedProposal = {
   type: ProposalType
   createdAt: Date
   status: string
-  signer: string
+  signers: string[]
   fee: number
   feeFiat?: number
 }
@@ -299,6 +302,7 @@ export type KeyAgentPaymentProposalPayload = SpendProposalPayload & {
 export type BaseKeyAgentPaymentProposal = {
   signer_descriptor: string,
   period: Period,
+  policy_path?: PolicyPath
 }
 
 export type PublishedKeyAgentPaymentProposal = PublishedProposal & BaseProposal & BaseKeyAgentPaymentProposal & BaseSpendingProposal & BaseFiat & {
@@ -382,3 +386,5 @@ export type DirectMessagesPayload = {
   messages: PublishedDirectMessage[]
   newConversationsIds: string[]
 }
+
+export type Item = Map<string, any>


### PR DESCRIPTION
Adds a `signers` property to Proposals,  which contains the fingerprints of the signers the user can use the approve the proposal