### PR TITLE
fix/retry-on-failure-events

### DIFF
--- a/src/SmartVaults.ts
+++ b/src/SmartVaults.ts
@@ -236,12 +236,6 @@ export class SmartVaults {
       .toFilters()
     const metadataEvents = await this.nostrClient.list(metadataFilter)
     const profiles: SmartVaultsTypes.Profile[] = await this.eventKindHandlerFactor.getHandler(Kind.Metadata).handle(metadataEvents)
-    const verifiedKeyAgentsPubkeys = new Set(await this.getVerifiedKeyAgentsPubKeys())
-    const unverifiedKeyAgentsPubkeys = await this.getUnverifiedKeyAgentEventsByPubkey()
-    profiles.forEach(profile => {
-      profile.isKeyAgent = unverifiedKeyAgentsPubkeys.has(profile.publicKey) || verifiedKeyAgentsPubkeys.has(profile.publicKey)
-      profile.isVerified = verifiedKeyAgentsPubkeys.has(profile.publicKey)
-    })
     return profiles
   }
 

--- a/src/event-kind-handler/MetadataHandler.ts
+++ b/src/event-kind-handler/MetadataHandler.ts
@@ -42,7 +42,7 @@ export class MetadataHandler extends EventKindHandler {
         }
       }
 
-      this.store.store({ content: { publicKey, ...metadata }, id: event.id });
+      this.store.store({ content: { publicKey, ...metadata, isKeyAgent: false, isVerified: false }, id: event.id });
     });
 
     const results = await Promise.allSettled(fetchPromises);

--- a/src/util/NostrUtil.ts
+++ b/src/util/NostrUtil.ts
@@ -77,7 +77,7 @@ export function getTagValue(
  * @example
  * const isNip05Verified = await isNip05Verified(alice@smartvaults.app, aliciesPublicKey);
  */
-export async function isNip05Verified(nip05: string, publicKey: string, timeout = 700): Promise<boolean> {
+export async function isNip05Verified(nip05: string, publicKey: string, timeout = 1000): Promise<boolean> {
 
   const HTTP_OK = 200;
   const nip05Array = nip05.split('@');


### PR DESCRIPTION
Automatic retry for failed-to-publish events is added:

This is useful given the possibility of failure of delete events in particular, since if the delete event is not published on all relays, the event that is being deleted will continue to show up.

The query for key agency status is removed since is not needed a the moment.