### PR TITLE
Fix/retry on failure events

### DIFF
--- a/src/SmartVaults.test.ts
+++ b/src/SmartVaults.test.ts
@@ -29,8 +29,6 @@ describe('SmartVaults', () => {
     keySet2 = keySet1.derive(2)
     altKeySet = new KeySet(2)
     nostrClient = new NostrClient([
-      //'wss://relay.rip',
-      // 'wss://test.relay.report'
       'ws://localhost:7777'
     ])
     bitcoinUtil = mock<BitcoinUtil>()
@@ -53,7 +51,7 @@ describe('SmartVaults', () => {
     jest.spyOn(smartVaults, 'signedPsbtSanityCheck').mockResolvedValue()
   })
 
-  afterEach(() => {
+  afterAll(() => {
     smartVaults.disconnect()
   })
 

--- a/src/SmartVaults.ts
+++ b/src/SmartVaults.ts
@@ -50,7 +50,7 @@ export class SmartVaults {
     this.stores.set(SmartVaultsKind.Proposal, Store.createMultiIndexStore(["proposal_id", "policy_id"], "proposal_id"))
     this.stores.set(SmartVaultsKind.ApprovedProposal, Store.createMultiIndexStore(["approval_id", "proposal_id", "policy_id"], "approval_id"))
     this.stores.set(SmartVaultsKind.SharedKey, Store.createSingleIndexStore("policyId"))
-    this.stores.set(SmartVaultsKind.CompletedProposal, Store.createMultiIndexStore(["id", "txId", "policy_id"], "id"))
+    this.stores.set(SmartVaultsKind.CompletedProposal, Store.createMultiIndexStore(["id", "txId", "policy_id", "proposal_id"], "id"))
     this.stores.set(SmartVaultsKind.SharedSigners, Store.createSingleIndexStore("id"))
     this.stores.set(SmartVaultsKind.Signers, Store.createSingleIndexStore("id"))
     this.stores.set(Kind.Metadata, Store.createSingleIndexStore("id"))
@@ -61,6 +61,7 @@ export class SmartVaults {
     this.stores.set(SmartVaultsKind.VerifiedKeyAgents, Store.createMultiIndexStore(["eventId", "pubkey"], "pubkey"))
     this.stores.set(SmartVaultsKind.KeyAgents, Store.createMultiIndexStore(["eventId", "pubkey"], "pubkey"))
     this.stores.set(Kind.EncryptedDirectMessage, Store.createMultiIndexStore(["id", "conversationId"], "id"))
+    this.stores.set(Kind.EventDeletion, Store.createSingleIndexStore("id"))
   }
 
   initEventKindHandlerFactory() {

--- a/src/event-kind-handler/EventDeletionHandler.ts
+++ b/src/event-kind-handler/EventDeletionHandler.ts
@@ -43,6 +43,12 @@ export class EventDeletionHandler extends EventKindHandler {
             const existingPayload = payloadMap.get(kind) || [];
             existingPayload.push(id);
             payloadMap.set(kind, existingPayload);
+            const eventDeleteStore = this.stores.get(Kind.EventDeletion)
+            if (eventDeleteStore) {
+              eventDeleteStore.store({ id: event.id, content: event.content })
+            } else {
+              console.log(`EventDeletion store not found`)
+            }
           }
         }
       };

--- a/src/event-kind-handler/EventDeletionHandler.ts
+++ b/src/event-kind-handler/EventDeletionHandler.ts
@@ -45,7 +45,7 @@ export class EventDeletionHandler extends EventKindHandler {
             payloadMap.set(kind, existingPayload);
             const eventDeleteStore = this.stores.get(Kind.EventDeletion)
             if (eventDeleteStore) {
-              eventDeleteStore.store({ id: event.id, content: event.content })
+              eventDeleteStore.store({ id: event.id, kind: event.kind })
             } else {
               console.log(`EventDeletion store not found`)
             }

--- a/src/event-kind-handler/EventKindHandlerFactory.ts
+++ b/src/event-kind-handler/EventKindHandlerFactory.ts
@@ -62,6 +62,7 @@ export class EventKindHandlerFactory {
       const approvalsStore = stores.get(SmartVaultsKind.ApprovedProposal)!
       const sharedKeysStore = stores.get(SmartVaultsKind.SharedKey)!
       const transactionMetadataStore = stores.get(SmartVaultsKind.TransactionMetadata)!
+      const eventDeleteStore = stores.get(Kind.EventDeletion)!
       const network = this.smartVaults.network
       switch (eventKind) {
         case SmartVaultsKind.Policy:
@@ -69,7 +70,7 @@ export class EventKindHandlerFactory {
             getSharedKeysById, getCompletedProposalsByPolicyId, getProposalsByPolicyId, getApprovalsByPolicyId, getSharedSigners, getOwnedSigners, getTransactionMetadataByPolicyId, saveTransactionMetadata))
           break
         case SmartVaultsKind.Proposal:
-          this.handlers.set(eventKind, new ProposalHandler(stores.get(eventKind)!, eventsStore, approvalsStore, nostrClient, bitcoinUtil, authenticator, getSharedKeysById, checkPsbts, getOwnedSigners, getApprovalsByProposalId, getPoliciesById))
+          this.handlers.set(eventKind, new ProposalHandler(stores.get(eventKind)!, eventsStore, approvalsStore, completedProposalsStore, eventDeleteStore, nostrClient, bitcoinUtil, authenticator, getSharedKeysById, checkPsbts, getOwnedSigners, getApprovalsByProposalId, getPoliciesById))
           break
         case SmartVaultsKind.ApprovedProposal:
           this.handlers.set(eventKind, new ApprovalsHandler(stores.get(eventKind)!, eventsStore, nostrClient, authenticator, getSharedKeysById))

--- a/src/event-kind-handler/ProposalHandler.ts
+++ b/src/event-kind-handler/ProposalHandler.ts
@@ -11,6 +11,8 @@ export class ProposalHandler extends EventKindHandler {
   private readonly store: Store
   private readonly eventsStore: Store
   private readonly approvalsStore: Store
+  private readonly completedProposalStore: Store
+  private readonly eventDeletionStore: Store
   private readonly nostrClient: NostrClient
   private readonly bitcoinUtil: BitcoinUtil
   private readonly authenticator: Authenticator
@@ -24,6 +26,8 @@ export class ProposalHandler extends EventKindHandler {
     store: Store,
     eventsStore: Store,
     approvalsStore: Store,
+    completedProposalStore: Store,
+    eventDeletionStore: Store,
     nostrClient: NostrClient,
     bitcoinUtil: BitcoinUtil,
     authenticator: Authenticator,
@@ -35,6 +39,8 @@ export class ProposalHandler extends EventKindHandler {
     this.store = store
     this.eventsStore = eventsStore
     this.approvalsStore = approvalsStore
+    this.completedProposalStore = completedProposalStore
+    this.eventDeletionStore = eventDeletionStore
     this.nostrClient = nostrClient
     this.bitcoinUtil = bitcoinUtil
     this.authenticator = authenticator
@@ -46,6 +52,7 @@ export class ProposalHandler extends EventKindHandler {
   }
 
   protected async _handle<K extends number>(proposalEvents: Array<Event<K>>): Promise<Array<ActivePublishedProposal | PublishedKeyAgentPaymentProposal>> {
+    proposalEvents = proposalEvents.filter(e => !this.eventDeletionStore.has(e.id) && !this.completedProposalStore.has(e.id, 'proposal_id'))
     const proposalIds = proposalEvents.map(proposal => proposal.id)
     if (!proposalIds.length) return []
     const policiesIds = proposalEvents.map(proposal => getTagValues(proposal, TagType.Event)[0])


### PR DESCRIPTION
Created a store to save delete events received so we can filter out proposals that have been deleted for at least one relay.
Proposals that have an associated completed proposal are now filtered out.

This is needed to ensure that when broadcasting a proposal on mobile, desktop or web, even if the delete event fails (completely or only on some relays), we can stop showing the (now finalized) Proposal and not wait for relays to sync or retries to succeed.

Updated NostrClient to clear any pending retries when disconnecting.